### PR TITLE
Fix sauna info selector

### DIFF
--- a/components/weather-dashboard.js
+++ b/components/weather-dashboard.js
@@ -711,7 +711,8 @@ class WeatherDashboard {
             const saunaStatusElement = document.getElementById("sauna-status");
             const toggleButton = document.getElementById("sauna-toggle");
             const saunaCard = document.getElementById("sauna-info");
-            const saunaInfoElement = document.querySelector(".sauna-info");
+            const saunaInfoElement =
+                document.querySelector(".sauna-info") || saunaCard;
             
             let temperatureInFahrenheit = 0;
             let targetTempFahrenheit = 0;


### PR DESCRIPTION
### Summary
- patch UI query to default to sauna card if `.sauna-info` class not present

### Testing
- `node scripts/app.js` *(fails: window is not defined)*