### PR TITLE
Fix UV tile styling

### DIFF
--- a/components/weather-dashboard.js
+++ b/components/weather-dashboard.js
@@ -170,12 +170,12 @@ class WeatherDashboard {
         const uvElement = uvCard.querySelector(".uv-value");
 
         if (uv !== "--" && !isNaN(parseFloat(uv))) {
-          uvElement.textContent = `UV: ${parseFloat(uv).toFixed(1)}`;
+          uvElement.textContent = parseFloat(uv).toFixed(1);
         } else {
-          uvElement.textContent = "UV: --";
+          uvElement.textContent = "--";
         }
 
-        uvElement.className = "uv-value";
+        uvElement.className = "big-value uv-value";
         if (uv !== "--") {
           const uvValue = parseFloat(uv);
           if (uvValue >= 11) {

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
       <article class="card" id="uv-card">
         <div class="atmos-animation-container"></div>
         <h3>UV</h3>
-        <div class="big-value uv-value">UV: --</div>
+        <div class="big-value uv-value">--</div>
         <div class="solar-value">-- W/m²</div>
       </article>
       <article class="card" id="last-update">

--- a/styles.css
+++ b/styles.css
@@ -115,6 +115,11 @@ body {
   color: var(--text-muted);
 }
 
+.solar-value {
+  font-size: 1.25rem;
+  color: var(--text-muted);
+}
+
 .status-text {
   margin-top: 0.25rem;
   color: var(--text-muted);


### PR DESCRIPTION
### Summary
- trim the UV value label in the dashboard markup
- ensure UV readings keep the big-value style in JS
- style solar values the same as sub-values for consistency

### Testing
- `./setup.sh`
- `node -v`
