### PR TITLE
Fix navigation links blocked by particle overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -30,6 +30,7 @@ body {
   position: fixed;
   inset: 0;
   z-index: 0;
+  pointer-events: none;
 }
 
 .dashboard {


### PR DESCRIPTION
### Summary
- disable pointer events on the background particle effect

### Testing
- `./setup.sh`
- `node -e "console.log('Node works')"`
- `python3 - <<'EOF'
print('Python works')
EOF`